### PR TITLE
Fix root crate binary config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,3 @@ lto = true
 codegen-units = 1
 panic = "abort"
 
-[[bin]]
-name = "udcn"
-path = "src/main.rs"


### PR DESCRIPTION
## Summary
- remove unused `[[bin]]` section from the root crate

The root `Cargo.toml` referenced `src/main.rs` but there is no such file. The CLI
crate builds the actual `udcn` executable (see Dockerfile), so the bin section
is unnecessary.

## Testing
- `cargo check` *(fails: could not compile `rust-udcn-quic`)*

------
https://chatgpt.com/codex/tasks/task_e_686191e9b4148327a1790692a273ad55