### PR TITLE
Validate NDN name parsing

### DIFF
--- a/rust-udcn-cli/src/commands/benchmark.rs
+++ b/rust-udcn-cli/src/commands/benchmark.rs
@@ -86,7 +86,8 @@ pub async fn run_benchmark(count: usize, prefix: String, concurrent: usize) -> R
             for i in start_index..end_index {
                 // Create a unique name for this interest
                 let name_str = format!("{}/{}", prefix_clone, i);
-                let name = Name::from_string(&name_str).unwrap();
+                let name = Name::from_string(&name_str)
+                    .expect("failed to parse benchmark name");
 
                 // Create an interest
                 let mut interest = Interest::new(name);


### PR DESCRIPTION
## Summary
- validate name parts when parsing from string
- update benchmark command for new `Name::from_string` result type

## Testing
- `cargo test -p rust-udcn-common --quiet`
- `cargo test -p rust-udcn-cli --quiet` *(fails: `rust-udcn-ebpf` build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861930e3f308327a8579256f7509b88