### PR TITLE
Fix network error variant usage

### DIFF
--- a/rust-udcn-quic/src/face.rs
+++ b/rust-udcn-quic/src/face.rs
@@ -152,7 +152,7 @@ impl Face {
                     
                     Err(anyhow!("Interest timed out"))
                 }
-                Ok(InterestResult::NetworkError(err)) => {
+                Ok(InterestResult::Dropped(err)) => {
                     debug!("[Face {}] Network error for Interest {}: {}", self.id, name, err);
                     Err(anyhow!("Network error: {}", err))
                 }
@@ -219,7 +219,7 @@ impl Face {
         // Notify all pending interests
         let mut pending = self.pending_interests.lock().await;
         for (name, sender) in pending.drain() {
-            let _ = sender.send(InterestResult::NetworkError("Face closed".to_string()));
+            let _ = sender.send(InterestResult::Dropped("Face closed".to_string()));
         }
         
         // Send a closed event
@@ -301,7 +301,7 @@ impl Face {
                 // Notify all pending interests
                 let mut pending = pending_interests.lock().await;
                 for (name, sender) in pending.drain() {
-                    let _ = sender.send(InterestResult::NetworkError("Connection closed".to_string()));
+                    let _ = sender.send(InterestResult::Dropped("Connection closed".to_string()));
                 }
                 
                 // Send a closed event


### PR DESCRIPTION
## Summary
- use existing `InterestResult::Dropped` variant for network errors

## Testing
- `cargo check` *(fails: could not compile due to unrelated errors)*

------
https://chatgpt.com/codex/tasks/task_e_68619c3ce4c8832782c1c5afc696275d