### PR TITLE
Implement TLV encode/decode

### DIFF
--- a/rust-udcn-common/src/ndn.rs
+++ b/rust-udcn-common/src/ndn.rs
@@ -5,7 +5,8 @@
 
 use crate::error::Error;
 use crate::tlv::{self, TlvElement};
-use bytes::{Buf, Bytes, BytesMut};            // ← removed BufMut (unused)
+use crate::Result;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::time::{Duration, Instant};
@@ -37,11 +38,12 @@ impl NameComponent {
         TlvElement::new(tlv::TLV_COMPONENT, self.0.clone())
     }
 
-    pub fn from_tlv(element: &TlvElement) -> Result<Self, Error> {
+    pub fn from_tlv(element: &TlvElement) -> Result<Self> {
         if element.tlv_type != tlv::TLV_COMPONENT {
             return Err(Error::NdnPacket(format!(
                 "Expected name component TLV type {}, got {}",
-                tlv::TLV_COMPONENT, element.tlv_type
+                tlv::TLV_COMPONENT,
+                element.tlv_type
             )));
         }
         Ok(Self(element.value.clone()))
@@ -50,10 +52,7 @@ impl NameComponent {
 
 impl fmt::Display for NameComponent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let printable = self
-            .0
-            .iter()
-            .all(|&b| (b.is_ascii_graphic() || b == b' '));
+        let printable = self.0.iter().all(|&b| (b.is_ascii_graphic() || b == b' '));
         if printable {
             write!(f, "{}", String::from_utf8_lossy(&self.0))
         } else {
@@ -78,16 +77,14 @@ impl Name {
         }
     }
 
-    pub fn from_string(s: &str) -> Result<Self, Error> {
-        let parts: Vec<&str> = s
-            .split('/')
-            .filter(|comp| !comp.is_empty())
-            .collect();
+    pub fn from_string(s: &str) -> Result<Self> {
+        let parts: Vec<&str> = s.split('/').filter(|comp| !comp.is_empty()).collect();
 
         if parts.len() > MAX_NAME_COMPONENTS {
             return Err(Error::NdnPacket(format!(
                 "Name has too many components: {} > {}",
-                parts.len(), MAX_NAME_COMPONENTS
+                parts.len(),
+                MAX_NAME_COMPONENTS
             )));
         }
 
@@ -140,7 +137,7 @@ impl Name {
             .all(|(a, b)| a == b)
     }
 
-    pub fn to_tlv(&self) -> Result<TlvElement, Error> {
+    pub fn to_tlv(&self) -> Result<TlvElement> {
         let mut buf = BytesMut::new();
         for component in &self.components {
             component.to_tlv().encode(&mut buf);
@@ -148,11 +145,12 @@ impl Name {
         Ok(TlvElement::new(tlv::TLV_NAME, buf.freeze()))
     }
 
-    pub fn from_tlv(element: &TlvElement) -> Result<Self, Error> {
+    pub fn from_tlv(element: &TlvElement) -> Result<Self> {
         if element.tlv_type != tlv::TLV_NAME {
             return Err(Error::NdnPacket(format!(
                 "Expected name TLV type {}, got {}",
-                tlv::TLV_NAME, element.tlv_type
+                tlv::TLV_NAME,
+                element.tlv_type
             )));
         }
 
@@ -234,8 +232,114 @@ impl Interest {
         self
     }
 
-    pub fn wire_size(&self) -> Result<usize, Error> {
+    pub fn wire_size(&self) -> Result<usize> {
         Ok(self.name.to_tlv()?.len() + 20) // rough estimate
+    }
+
+    /// Return the Interest name
+    pub fn name(&self) -> &Name {
+        &self.name
+    }
+
+    /// Encode the Interest into TLV wire format
+    pub fn encode(&self, buf: &mut BytesMut) -> Result<()> {
+        let mut inner = BytesMut::new();
+
+        // Name
+        self.name.to_tlv()?.encode(&mut inner);
+
+        // Selectors (encode CanBePrefix and MustBeFresh as two bytes)
+        let mut selectors = BytesMut::new();
+        selectors.put_u8(self.can_be_prefix as u8);
+        selectors.put_u8(self.must_be_fresh as u8);
+        TlvElement::new(tlv::TLV_SELECTORS, selectors.freeze()).encode(&mut inner);
+
+        // Nonce
+        let mut nonce_buf = BytesMut::new();
+        nonce_buf.put_u32(self.nonce);
+        TlvElement::new(tlv::TLV_NONCE, nonce_buf.freeze()).encode(&mut inner);
+
+        // Lifetime
+        let mut life_buf = BytesMut::new();
+        life_buf.put_u32(self.lifetime_ms);
+        TlvElement::new(tlv::TLV_INTEREST_LIFETIME, life_buf.freeze()).encode(&mut inner);
+
+        // HopLimit if present (TLV type 0x22 as in NDN spec)
+        if let Some(hop) = self.hop_limit {
+            let mut hop_buf = BytesMut::new();
+            hop_buf.put_u8(hop);
+            TlvElement::new(0x22, hop_buf.freeze()).encode(&mut inner);
+        }
+
+        TlvElement::new(tlv::TLV_INTEREST, inner.freeze()).encode(buf);
+        Ok(())
+    }
+
+    /// Decode an Interest from TLV wire format
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        let mut buf = Bytes::from(bytes.to_vec());
+        let outer = TlvElement::decode(&mut buf)?;
+        if outer.tlv_type != tlv::TLV_INTEREST {
+            return Err(Error::NdnPacket(format!(
+                "Expected Interest type {}, got {}",
+                tlv::TLV_INTEREST,
+                outer.tlv_type
+            )));
+        }
+
+        let mut inner = outer.value.clone();
+        let mut name = None;
+        let mut nonce = None;
+        let mut lifetime_ms = None;
+        let mut hop_limit = None;
+        let mut can_be_prefix = false;
+        let mut must_be_fresh = false;
+
+        while inner.has_remaining() {
+            let e = TlvElement::decode(&mut inner)?;
+            match e.tlv_type {
+                tlv::TLV_NAME => {
+                    name = Some(Name::from_tlv(&e)?);
+                }
+                tlv::TLV_NONCE => {
+                    let mut nbuf = e.value.clone();
+                    if nbuf.remaining() == 4 {
+                        nonce = Some(nbuf.get_u32());
+                    }
+                }
+                tlv::TLV_INTEREST_LIFETIME => {
+                    let mut lbuf = e.value.clone();
+                    if lbuf.remaining() >= 1 && lbuf.remaining() <= 4 {
+                        let mut tmp = [0u8; 4];
+                        for (i, b) in lbuf.iter().rev().enumerate() {
+                            tmp[3 - i] = *b;
+                        }
+                        lifetime_ms = Some(u32::from_be_bytes(tmp));
+                    }
+                }
+                tlv::TLV_SELECTORS => {
+                    if e.value.len() >= 2 {
+                        can_be_prefix = e.value[0] != 0;
+                        must_be_fresh = e.value[1] != 0;
+                    }
+                }
+                0x22 => {
+                    if !e.value.is_empty() {
+                        hop_limit = Some(e.value[0]);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Ok(Self {
+            name: name.ok_or_else(|| Error::NdnPacket("Interest missing name".into()))?,
+            nonce: nonce.unwrap_or(0),
+            lifetime_ms: lifetime_ms.unwrap_or(4000),
+            hop_limit,
+            can_be_prefix,
+            must_be_fresh,
+        })
     }
 }
 
@@ -263,7 +367,7 @@ pub struct Data {
 }
 
 impl<'de> Deserialize<'de> for Data {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -296,8 +400,69 @@ impl Data {
         self.creation_time.elapsed() > Duration::from_millis(self.ttl_ms as u64)
     }
 
-    pub fn wire_size(&self) -> Result<usize, Error> {
+    pub fn wire_size(&self) -> Result<usize> {
         Ok(self.name.to_tlv()?.len() + self.content.len() + 20)
+    }
+
+    /// Return the Data name
+    pub fn name(&self) -> &Name {
+        &self.name
+    }
+
+    /// Return the content bytes
+    pub fn content(&self) -> &Bytes {
+        &self.content
+    }
+
+    /// Encode the Data packet into TLV wire format
+    pub fn encode(&self, buf: &mut BytesMut) -> Result<()> {
+        let mut inner = BytesMut::new();
+
+        // Name
+        self.name.to_tlv()?.encode(&mut inner);
+
+        // Content
+        TlvElement::new(tlv::TLV_CONTENT, self.content.clone()).encode(&mut inner);
+
+        TlvElement::new(tlv::TLV_DATA, inner.freeze()).encode(buf);
+        Ok(())
+    }
+
+    /// Decode a Data packet from TLV wire format
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        let mut buf = Bytes::from(bytes.to_vec());
+        let outer = TlvElement::decode(&mut buf)?;
+        if outer.tlv_type != tlv::TLV_DATA {
+            return Err(Error::NdnPacket(format!(
+                "Expected Data type {}, got {}",
+                tlv::TLV_DATA,
+                outer.tlv_type
+            )));
+        }
+
+        let mut inner = outer.value.clone();
+        let mut name = None;
+        let mut content = Bytes::new();
+
+        while inner.has_remaining() {
+            let e = TlvElement::decode(&mut inner)?;
+            match e.tlv_type {
+                tlv::TLV_NAME => {
+                    name = Some(Name::from_tlv(&e)?);
+                }
+                tlv::TLV_CONTENT => {
+                    content = e.value.clone();
+                }
+                _ => {}
+            }
+        }
+
+        Ok(Self {
+            name: name.ok_or_else(|| Error::NdnPacket("Data missing name".into()))?,
+            content,
+            ttl_ms: 10_000,
+            creation_time: Instant::now(),
+        })
     }
 }
 

--- a/rust-udcn-quic/src/packet.rs
+++ b/rust-udcn-quic/src/packet.rs
@@ -4,7 +4,7 @@
 //! for transmission over QUIC.
 
 use anyhow::{anyhow, Result};
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut};
 use log::{debug, trace};
 use rust_udcn_common::ndn::{Data, Interest};
 
@@ -17,7 +17,7 @@ const PACKET_TYPE_DATA: u8 = 0x06;
 pub enum NdnPacket {
     /// An Interest packet
     Interest(Interest),
-    
+
     /// A Data packet
     Data(Data),
 }
@@ -28,7 +28,7 @@ impl NdnPacket {
         if bytes.is_empty() {
             return Err(anyhow!("Empty packet"));
         }
-        
+
         // The first byte indicates the packet type in NDN-TLV
         match bytes[0] {
             PACKET_TYPE_INTEREST => {
@@ -74,7 +74,7 @@ impl NdnPacket {
             NdnPacket::Data(_) => "Data",
         }
     }
-    
+
     /// Get the size of the packet in bytes
     pub fn size(&self) -> Result<usize> {
         Ok(self.to_bytes()?.len())


### PR DESCRIPTION
## Summary
- implement TLV encode/decode for Interest and Data
- expose simple accessors and use them from QUIC packet module

## Testing
- `cargo check -p rust-udcn-common`

------
https://chatgpt.com/codex/tasks/task_e_68619f6d9d3083278bae7a2e596af019