### PR TITLE
Fix build failures

### DIFF
--- a/rust-udcn-common/src/metrics.rs
+++ b/rust-udcn-common/src/metrics.rs
@@ -237,6 +237,8 @@ pub struct UdcnMetrics {
     pub interests_received: Counter,
     pub interests_satisfied: Counter,
     pub interests_timed_out: Counter,
+    /// Number of Interests sent out
+    pub interests_sent: Counter,
     pub interests_forwarded: Counter,
     pub data_received: Counter,
     pub data_sent: Counter,

--- a/rust-udcn-common/src/ndn.rs
+++ b/rust-udcn-common/src/ndn.rs
@@ -472,8 +472,10 @@ impl Data {
 
 #[derive(Debug, Clone)]
 pub enum InterestResult {
-    Forwarded,
-    SatisfiedByCs(Data),
-    Aggregated,
+    /// The Interest was satisfied with Data
+    Data(Data),
+    /// The Interest timed out
+    Timeout,
+    /// The Interest could not be satisfied and was dropped with a reason
     Dropped(String),
 }

--- a/rust-udcn-quic/Cargo.toml
+++ b/rust-udcn-quic/Cargo.toml
@@ -10,7 +10,7 @@ rust-udcn-common = { path = "../rust-udcn-common" }
 
 # -------- QUIC stack (API used by the code) ------------------------
 # quinn 0.10   ⇐⇒   rustls 0.20   ⇐⇒   webpki-roots 0.22
-quinn           = { version = "=0.9", default-features = false, features = ["rustls"] }
+quinn           = { version = "=0.9", default-features = false, features = ["tls-rustls"] }
 rustls          = { version = "=0.20", features = ["dangerous_configuration", "quic"] }
 webpki-roots    = "0.22"
 rustls-pemfile  = "1"        # you call certs()/pkcs8_private_keys() directly

--- a/rust-udcn-quic/src/lib.rs
+++ b/rust-udcn-quic/src/lib.rs
@@ -84,7 +84,7 @@ impl NdnQuicServer {
         let server_config = config::configure_server(&options).await?;
         
         // Create a QUIC endpoint
-        let (endpoint, _incoming) = Endpoint::server(
+        let endpoint = Endpoint::server(
             server_config.clone(),
             options.listen_addr.parse().context("Invalid listen address")?,
         )?;


### PR DESCRIPTION
## Summary
- add `interests_sent` metric
- rework InterestResult enum
- update QUIC config for `quinn` 0.9 API
- fix borrow and type issues in QUIC face implementation
- add panic handler for ebpf crate

## Testing
- `cargo build --release`

------
https://chatgpt.com/codex/tasks/task_e_6861a5a8a9108327b70c248bd019fdb2