### PR TITLE
Use build script for embedded ebpf

### DIFF
--- a/rust-udcn-xdp/Cargo.toml
+++ b/rust-udcn-xdp/Cargo.toml
@@ -3,6 +3,7 @@ name = "rust-udcn-xdp"
 version = "0.1.0"
 edition = "2021"
 description = "XDP userspace components for µDCN"
+build = "build.rs"
 
 [dependencies]
 aya = { version = "0.13.1", features = ["async_tokio"] }

--- a/rust-udcn-xdp/build.rs
+++ b/rust-udcn-xdp/build.rs
@@ -1,0 +1,42 @@
+use std::{env, fs, path::PathBuf, process::Command};
+
+fn main() {
+    // Location of the eBPF crate
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let ebpf_dir = manifest_dir.join("../rust-udcn-ebpf");
+
+    // Determine build profile (debug/release)
+    let profile = env::var("PROFILE").unwrap();
+
+    // Build the eBPF crate for the bpfel-unknown-none target
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build").arg("--target").arg("bpfel-unknown-none");
+    if profile == "release" {
+        cmd.arg("--release");
+    }
+    let status = cmd
+        .current_dir(&ebpf_dir)
+        .status()
+        .expect("failed to build eBPF program");
+    if !status.success() {
+        panic!("eBPF build failed");
+    }
+
+    // Copy the resulting object file to OUT_DIR
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let profile_dir = if profile == "release" {
+        "release"
+    } else {
+        "debug"
+    };
+    let src = ebpf_dir
+        .join("target")
+        .join("bpfel-unknown-none")
+        .join(profile_dir)
+        .join("rust_udcn_ebpf.o");
+    let dst = out_dir.join("rust_udcn_ebpf.o");
+    fs::create_dir_all(&out_dir).unwrap();
+    fs::copy(&src, &dst).expect("failed to copy eBPF object");
+
+    println!("cargo:rerun-if-changed={}", ebpf_dir.join("src").display());
+}

--- a/rust-udcn-xdp/src/lib.rs
+++ b/rust-udcn-xdp/src/lib.rs
@@ -57,15 +57,10 @@ impl XdpManager {
     /// Load the XDP program from the given path or use the embedded program
     pub async fn load_from_embedded() -> Result<Self> {
         // This will include the eBPF object file at compile time
-        #[cfg(debug_assertions)]
-        let mut bpf = Bpf::load(include_bytes_aligned!(
-            "../../target/bpfel-unknown-none/debug/rust_udcn_ebpf"
-        ))?;
-
-        #[cfg(not(debug_assertions))]
-        let mut bpf = Bpf::load(include_bytes_aligned!(
-            "../../target/bpfel-unknown-none/release/rust_udcn_ebpf"
-        ))?;
+        // The eBPF object compiled by the build script is placed in OUT_DIR
+        let mut bpf = Bpf::load(include_bytes_aligned!(concat!(
+            env!("OUT_DIR"), "/rust_udcn_ebpf.o"
+        )))?;
 
         // Initialize logging for the BPF program
         if let Err(e) = BpfLogger::init(&mut bpf) {


### PR DESCRIPTION
## Summary
- load the embedded eBPF object from `OUT_DIR`
- add build script that builds `rust-udcn-ebpf` for the `bpfel-unknown-none` target and copies the object to `OUT_DIR`

## Testing
- `cargo test --workspace` *(fails: could not compile `rust-udcn-ebpf`)*

------
https://chatgpt.com/codex/tasks/task_e_6861c24631308327a7cb575b3b4e88eb