### PR TITLE
Update aya maps import

### DIFF
--- a/rust-udcn-xdp/src/lib.rs
+++ b/rust-udcn-xdp/src/lib.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use aya::{
     include_bytes_aligned,
-    maps::{HashMap, LruHashMap, MapData},
+    maps::{HashMap, MapData, lru_hash_map::LruHashMap},
     programs::{Xdp, XdpFlags},
     Bpf,
 };


### PR DESCRIPTION
## Summary
- update rust-udcn-xdp to import `LruHashMap` from the submodule

## Testing
- `cargo check -p rust-udcn-xdp` *(fails: unwinding panics are not supported without std)*

------
https://chatgpt.com/codex/tasks/task_e_6861c3f3000083278508ae76155e4745